### PR TITLE
Allow VariableExpression in Fragment TemplateName

### DIFF
--- a/source/standard/expressions/ThymeleafExpressionLanguage.js
+++ b/source/standard/expressions/ThymeleafExpressionLanguage.js
@@ -181,7 +181,12 @@ export default new Grammar('Thymeleaf Expression Language',
 			};
 		}
 	),
-	new ThymeleafRule('TemplateName', /[\w-._/]+/),
+	new ThymeleafRule('TemplateName',
+ 		OrderedChoice(
+			/[\w-._/]+/,
+			'VariableExpression'
+		)
+ 	),
 	new ThymeleafRule('FragmentName', /[\w-._]+/),
 	new ThymeleafRule('FragmentParametersSection',
 		Sequence(/\(/, Optional('FragmentParameters'), /\)/),


### PR DESCRIPTION
From this change, it will be possible to use a variable as a template name.

For example:
```html
<div thjs:replace="~{${content} :: pageContent}"></div>
````